### PR TITLE
refreshing glass frame

### DIFF
--- a/Microsoft.Windows.Shell/WindowChrome.cs
+++ b/Microsoft.Windows.Shell/WindowChrome.cs
@@ -242,6 +242,18 @@ namespace Microsoft.Windows.Shell
             set { SetValue(UseAeroCaptionButtonsProperty, value); }
         }
 
+        public static readonly DependencyProperty IgnoreTaskbarOnMaximizeProperty = DependencyProperty.Register(
+            "IgnoreTaskbarOnMaximize",
+            typeof(bool),
+            typeof(WindowChrome),
+            new FrameworkPropertyMetadata(false));
+
+        public bool IgnoreTaskbarOnMaximize
+        {
+            get { return (bool)GetValue(IgnoreTaskbarOnMaximizeProperty); }
+            set { SetValue(IgnoreTaskbarOnMaximizeProperty, value); }
+        }
+
         public static readonly DependencyProperty CornerRadiusProperty = DependencyProperty.Register(
             "CornerRadius",
             typeof(CornerRadius),

--- a/Microsoft.Windows.Shell/WindowChromeWorker.cs
+++ b/Microsoft.Windows.Shell/WindowChromeWorker.cs
@@ -902,7 +902,7 @@ namespace Microsoft.Windows.Shell
                 IntPtr hMon = NativeMethods.MonitorFromWindow(_hwnd, MONITOR_DEFAULTTONEAREST);
 
                 MONITORINFO mi = NativeMethods.GetMonitorInfo(hMon);
-                RECT rcMax = mi.rcWork;
+                RECT rcMax = _chromeInfo.IgnoreTaskbarOnMaximize ? mi.rcMonitor : mi.rcWork;
                 // The location of maximized window takes into account the border that Windows was
                 // going to remove, so we also need to consider it.
                 rcMax.Offset(-left, -top);


### PR DESCRIPTION
with this change it is possible to get a maximized window with hidden taskbar.
so we can set initial `GlassFrameThickness = new Thickness(0)` with `WindowStyle=None` to get a custom window.
now if user maximize the window we can set `GlassFrameThickness = new Thickness(1)` to get a window that fills the complete monitor and hides the taskbar (this should happened in maximized event of the window).
with `GlassFrameThickness = new Thickness(0)` we can set back to a custom styled window without showing the glass frame.
this all works only with `WindowStyle=None`!

i hope this brakes nothing :-D

Closes #5 
