### PR TITLE
fix disappearing taskbar item

### DIFF
--- a/Microsoft.Windows.Shell/WindowChromeWorker.cs
+++ b/Microsoft.Windows.Shell/WindowChromeWorker.cs
@@ -796,7 +796,6 @@ namespace Microsoft.Windows.Shell
             {
                 _lastMenuState = state;
 
-                bool modified = _ModifyStyle(WS.VISIBLE, 0);
                 IntPtr hmenu = NativeMethods.GetSystemMenu(_hwnd, false);
                 if (IntPtr.Zero != hmenu)
                 {
@@ -830,11 +829,6 @@ namespace Microsoft.Windows.Shell
                             NativeMethods.EnableMenuItem(hmenu, SC.MAXIMIZE, canMaximize ? mfEnabled : mfDisabled);
                             break;
                     }
-                }
-
-                if (modified)
-                {
-                    _ModifyStyle(0, WS.VISIBLE);
                 }
             }
         }


### PR DESCRIPTION
i think its not necessary to set visibility on windows to false and after setting system menu to true

```csharp
bool modified = _ModifyStyle(WS.VISIBLE, 0);

...

if (modified)
{
  _ModifyStyle(0, WS.VISIBLE);
}
```

the problem

Windows 8.1 Settings:
2 monitors with extended desktop
Taskbar only visible on primary desktop
Repro:

Start the WPF application
Move the window on the secondary screen
Maximize the window on the secondary screen (for example by docking the
window on the top)
Restore and drag the window from the secondary screen to the primary
screen
--> The taskbar icon will disappear exactly when the mouse enters on the
primary screen!

If you do the same repro again the icon reappears.

Another repro:

- Maximize the application on second monitor
- Minimize the app and focus another application OR click somewhere on a
second monitor
- Focus/Activate the original application again
- The taskbar item disappeared (maybe only after second repro)