### PR TITLE
ExtendGlassFrame should be called when glass is enabled.

### DIFF
--- a/Microsoft.Windows.Shell/WindowChromeWorker.cs
+++ b/Microsoft.Windows.Shell/WindowChromeWorker.cs
@@ -856,12 +856,12 @@ namespace Microsoft.Windows.Shell
                 if (!_isGlassEnabled)
                 {
                     _SetRoundingRegion(null);
-                    _ExtendGlassFrame();
                 }
                 else
                 {
-                    _ClearRoundingRegion();
-                }
+					_ClearRoundingRegion();
+					_ExtendGlassFrame();
+				}
 
                 NativeMethods.SetWindowPos(_hwnd, IntPtr.Zero, 0, 0, 0, 0, _SwpFlags);
             }


### PR DESCRIPTION
Hey Joe,

Below is the simple change that I needed to make in order to get the glassy style working again.

As I browsed through the history, though, I could see that punker76's changes were in this area as well. Apparently, he had a scenario where he was programmatically changing the GlassThickness to 0, then to X, and then to 0 again. In other words, I am not entirely positive that this is the change you want in general. It may make sense to have the _ExtendGlassFrame following the if/else ... but then you manually got rid of that change.

What is clear, however, is that the _ExtendGlassFrame call needs to run when glass is enabled.

Cory
