### PR TITLE
Wrapping GetCurrentThemeName in a try/catch.

### DIFF
--- a/Microsoft.Windows.Shell/SystemParameters2.cs
+++ b/Microsoft.Windows.Shell/SystemParameters2.cs
@@ -213,24 +213,36 @@ namespace Microsoft.Windows.Shell
             _InitializeHighContrast();
         }
 
-        private void _InitializeThemeInfo()
-        {
-            if (!NativeMethods.IsThemeActive())
-            {
-                UxThemeName = "Classic";
-                UxThemeColor = "";
-                return;
-            }
+		private void _InitializeThemeInfo()
+		{
+			if (!NativeMethods.IsThemeActive())
+			{
+				UxThemeName = "Classic";
+				UxThemeColor = "";
+				return;
+			}
 
-            string name;
-            string color;
-            string size;
-            NativeMethods.GetCurrentThemeName(out name, out color, out size);
+			try
+			{
+				// wrap GetCurrentThemeName in a try/catch as we were seeing an exception
+				// even though the theme service seemed to be active (UxTheme IsThemeActive)
+				// see http://stackoverflow.com/questions/8893854/wpf-application-ribbon-crash as an example.
 
-            // Consider whether this is the most useful way to expose this...
-            UxThemeName = System.IO.Path.GetFileNameWithoutExtension(name);
-            UxThemeColor = color;
-        }
+				string name;
+				string color;
+				string size;
+				NativeMethods.GetCurrentThemeName(out name, out color, out size);
+
+				// Consider whether this is the most useful way to expose this...
+				UxThemeName = System.IO.Path.GetFileNameWithoutExtension(name);
+				UxThemeColor = color;
+			}
+			catch (Exception)
+			{
+				UxThemeName = "Classic";
+				UxThemeColor = "";
+			}
+		}
 
         private void _UpdateThemeInfo(IntPtr wParam, IntPtr lParam)
         {

--- a/Microsoft.Windows.Shell/SystemParameters2.cs
+++ b/Microsoft.Windows.Shell/SystemParameters2.cs
@@ -213,36 +213,36 @@ namespace Microsoft.Windows.Shell
             _InitializeHighContrast();
         }
 
-		private void _InitializeThemeInfo()
-		{
-			if (!NativeMethods.IsThemeActive())
-			{
-				UxThemeName = "Classic";
-				UxThemeColor = "";
-				return;
-			}
+        private void _InitializeThemeInfo()
+        {
+            if (!NativeMethods.IsThemeActive())
+            {
+                UxThemeName = "Classic";
+                UxThemeColor = "";
+                return;
+            }
 
-			try
-			{
-				// wrap GetCurrentThemeName in a try/catch as we were seeing an exception
-				// even though the theme service seemed to be active (UxTheme IsThemeActive)
-				// see http://stackoverflow.com/questions/8893854/wpf-application-ribbon-crash as an example.
+            try
+            {
+                // wrap GetCurrentThemeName in a try/catch as we were seeing an exception
+                // even though the theme service seemed to be active (UxTheme IsThemeActive)
+                // see http://stackoverflow.com/questions/8893854/wpf-application-ribbon-crash as an example.
 
-				string name;
-				string color;
-				string size;
-				NativeMethods.GetCurrentThemeName(out name, out color, out size);
+                string name;
+                string color;
+                string size;
+                NativeMethods.GetCurrentThemeName(out name, out color, out size);
 
-				// Consider whether this is the most useful way to expose this...
-				UxThemeName = System.IO.Path.GetFileNameWithoutExtension(name);
-				UxThemeColor = color;
-			}
-			catch (Exception)
-			{
-				UxThemeName = "Classic";
-				UxThemeColor = "";
-			}
-		}
+                // Consider whether this is the most useful way to expose this...
+                UxThemeName = System.IO.Path.GetFileNameWithoutExtension(name);
+                UxThemeColor = color;
+            }
+            catch (Exception)
+            {
+                UxThemeName = "Classic";
+                UxThemeColor = "";
+            }
+        }
 
         private void _UpdateThemeInfo(IntPtr wParam, IntPtr lParam)
         {


### PR DESCRIPTION
I've just run into a really weird exception in wpf-shell. See below, but the exception happens when trying to create a window with our custom chrome (which is built on top of wpf-shell). _GetCurrentThemeName is the method that is returning a bad HRESULT and then throwing the exception.

> System.Windows.Markup.XamlParseException: The invocation of the constructor on type 'Microsoft.Windows.Shell.WindowChrome' that matches the specified binding constraints threw an exception. ---> System.ComponentModel.Win32Exception: HRESULT_FROM_WIN32(ERROR_NOT_FOUND)
>    at Standard.HRESULT.ThrowIfFailed(String message)
>    at Standard.NativeMethods.GetCurrentThemeName(String& themeFileName, String& color, String& size)
>    at Microsoft.Windows.Shell.SystemParameters2._InitializeThemeInfo()
>    at Microsoft.Windows.Shell.SystemParameters2..ctor()
>    at Microsoft.Windows.Shell.SystemParameters2.get_Current()
>    at Microsoft.Windows.Shell.WindowChrome..ctor()

I think some other people have run into this as well:
http://stackoverflow.com/questions/8893854/wpf-application-ribbon-crash
